### PR TITLE
py.test.set_trace() doesn't work without -s option

### DIFF
--- a/pytestipdb/ptipdb.py
+++ b/pytestipdb/ptipdb.py
@@ -26,6 +26,17 @@ class PytestIpdb:
     def set_trace(self):
         """ invoke ipdb set_trace debugging, dropping any IO capturing. """
         frame = sys._getframe().f_back
+        item = self.item or self.collector
+
+        if item is not None:
+            capman = item.config.pluginmanager.getplugin("capturemanager")
+            out, err = capman.suspendcapture()
+            if hasattr(item, 'outerr'):
+                item.outerr = (item.outerr[0] + out, item.outerr[1] + err)
+            tw = py.io.TerminalWriter()
+            tw.line()
+            tw.sep(">", "PDB set_trace (IO-capturing turned off)")
+        frame = sys._getframe().f_back
         ipdb.set_trace(frame)
 
 def ipdbitem(item):


### PR DESCRIPTION
Hey,

I just tried out your plugin and it works pretty sweet, except for set_trace function seemed to fail because stdin was being overridden...  I initially used a hack to replace the stdoi streams but this didn't seem to work reliably, so here is a patch that uses the py.test capture API to revert the IO streams before starting the debugger.  I basically copied the code from the py.test pdb module and i'm not sure what the license requirements are for the MIT style licences.

I have tested this with the following configuration.

pytest-ipdb 6580b68
python 2.7.3
py.test 2.3.4
ipython 0.13.2

Cheers,
Russell
