### PR TITLE
Add .travis.yml for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - pypy
+  - 3.3
+install: pip install -e .
+script: py.test


### PR DESCRIPTION
This adds support for Travis CI.

Sample Travis CI build: https://travis-ci.org/msabramo/pytest-ipdb

(I'll send another PR to fix the Python 3.3 failure...) **[Tue Feb 25 07:43:37 PST 2014]: Here's the PR to fix the Python 3.3 test failure: https://github.com/mverteuil/pytest-ipdb/pull/20**

See this page for instructions on setting it up for your repo (it takes less than two minutes to set up - especially since I already have the `.travis.yml` file here if you merge this):

http://docs.travis-ci.com/user/getting-started/
