### PR TITLE
Fix py33 test failure; looser match for AttributeError

### DIFF
--- a/test_pytest_ipdb.py
+++ b/test_pytest_ipdb.py
@@ -75,7 +75,7 @@ def test_ipdb_set_trace(testdir, option):
 
     if option.no_ipdb:
         result.stdout.fnmatch_lines([
-            "*AttributeError: DontReadFromInput instance has no attribute 'encoding'",
+            "*AttributeError: *DontReadFromInput* has no attribute 'encoding'",
         ])
     else:
         result.stdout.fnmatch_lines([


### PR DESCRIPTION
Was failing to match `AttributeError` exception text for `DontReadFromInput` in Python 3.3, because the exception text is slightly different.
### Without this change:

```
 marca@marca-mac2.local ⮀ git-repos/pytest-ipdb ⮀ ⭠ fix_py33_test_failure ? ⮀
 ❯ .tox/py33/bin/py.test -k 'test_ipdb_set_trace[no_ipdb]'
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.3.3 -- py-1.4.20 -- pytest-2.5.2
plugins: ipdb
collected 6 items

test_pytest_ipdb.py F

=================================================================================== FAILURES ===================================================================================
_________________________________________________________________________ test_ipdb_set_trace[no_ipdb] _________________________________________________________________________

testdir = <TmpTestdir local('/private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-806/testdir/test_ipdb_set_trace0')>
option = <test_pytest_ipdb.Option object at 0x1018de610>

    def test_ipdb_set_trace(testdir, option):
        testdir.makepyfile(
            """
            import ipdb

            def test_func():
                ipdb.set_trace()
            """
        )

        result = testdir.runpytest(*option.args)

        if option.no_ipdb:
            result.stdout.fnmatch_lines([
>               "*AttributeError: DontReadFromInput instance has no attribute 'encoding'",
                # "*AttributeError: *DontReadFromInput* has no attribute 'encoding'",
            ])
E           Failed: remains unmatched: "*AttributeError: DontReadFromInput instance has no attribute 'encoding'", see stderr

/Users/marca/dev/git-repos/pytest-ipdb/test_pytest_ipdb.py:78: Failed
------------------------------------------------------------------------------- Captured stdout --------------------------------------------------------------------------------
running ['/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/bin/python3.3', '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/pytest.py', '--basetemp=/private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-806/testdir/test_ipdb_set_trace0/runpytest-0', '--pdb'] curdir= /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-806/testdir/test_ipdb_set_trace0
============================= test session starts ==============================
platform darwin -- Python 3.3.3 -- py-1.4.20 -- pytest-2.5.2
plugins: ipdb

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
test_ipdb_set_trace.py:1: in <module>
>   import ipdb
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/ipdb/__init__.py:16: in <module>
>   from ipdb.__main__ import set_trace, post_mortem, pm, run, runcall, runeval, launch_ipdb_on_exception
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/ipdb/__main__.py:51: in <module>
>           ipshell = InteractiveShellEmbed()
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/terminal/embed.py:97: in __init__
>           display_banner=display_banner
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/terminal/interactiveshell.py:320: in __init__
>           **kwargs
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:475: in __init__
>       self.init_readline()
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:1851: in init_readline
>           self.refill_readline_hist()
/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:1860: in refill_readline_hist
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: 'DontReadFromInput' object has no attribute 'encoding'
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py(1860)refill_readline_hist()
-> stdin_encoding = sys.stdin.encoding or "utf-8"
(Pdb)
collected 0 items / 1 errors

=========================== 1 error in 0.33 seconds ============================

------------------------------------------------------------------------------- Captured stderr --------------------------------------------------------------------------------
nomatch: "*AttributeError: DontReadFromInput instance has no attribute 'encoding'"
    and: '============================= test session starts =============================='
    and: 'platform darwin -- Python 3.3.3 -- py-1.4.20 -- pytest-2.5.2'
    and: 'plugins: ipdb'
    and: ''
    and: '>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
    and: 'test_ipdb_set_trace.py:1: in <module>'
    and: '>   import ipdb'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/ipdb/__init__.py:16: in <module>'
    and: '>   from ipdb.__main__ import set_trace, post_mortem, pm, run, runcall, runeval, launch_ipdb_on_exception'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/ipdb/__main__.py:51: in <module>'
    and: '>           ipshell = InteractiveShellEmbed()'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/terminal/embed.py:97: in __init__'
    and: '>           display_banner=display_banner'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/terminal/interactiveshell.py:320: in __init__'
    and: '>           **kwargs'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:475: in __init__'
    and: '>       self.init_readline()'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:1851: in init_readline'
    and: '>           self.refill_readline_hist()'
    and: '/Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py:1860: in refill_readline_hist'
    and: '>       stdin_encoding = sys.stdin.encoding or "utf-8"'
    and: "E       AttributeError: 'DontReadFromInput' object has no attribute 'encoding'"
    and: '>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
    and: '> /Users/marca/dev/git-repos/pytest-ipdb/.tox/py33/lib/python3.3/site-packages/IPython/core/interactiveshell.py(1860)refill_readline_hist()'
    and: '-> stdin_encoding = sys.stdin.encoding or "utf-8"'
    and: '(Pdb) '
    and: 'collected 0 items / 1 errors'
    and: ''
    and: '=========================== 1 error in 0.33 seconds ============================'
    and: '\x1b[?1034h'
============================================================ 5 tests deselected by '-ktest_ipdb_set_trace[no_ipdb]' ============================================================
==================================================================== 1 failed, 5 deselected in 0.63 seconds ====================================================================
```
### With this change:

```
[git branch: fix_py33_test_failure]
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  pypy: commands succeeded
  congratulations :)
```
