### PR TITLE
tox.ini: Pin pytest==2.5.2, {posargs}, add py34

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, pypy
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
+commands = py.test {posargs}
+deps =
+    pytest==2.5.2
+    ipdb
+
+[testenv:py26]
 commands = py.test
 deps =
-    pytest
+    pytest==2.5.2
+    ipython<2.0
     ipdb


### PR DESCRIPTION
- We pin pytest==2.5.2 for now, because tests fail on later versions.
- `{posargs}` allows passing arguments to py.test from the tox command line
- Add py34 as another environment to test on.

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  congratulations :)
```
