### PR TITLE
.travis.yml: Make it leverage tox to be DRY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - pypy
-  - 3.3
-install: pip install -e .
-script: py.test
+env:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=pypy
+    - TOXENV=py33
+    - TOXENV=py34
+install:
+    - travis_retry pip install tox
+script:
+    - travis_retry tox


### PR DESCRIPTION
This makes the `.travis.yml` leverage `tox.ini` so we have:
- less duplication (though there is not much)
- (more importantly) they are using the same mechanisms and get the same results -- I actually had a problem where the tox tests passed because they pinned pytest==2.5.2 but then the Travis tests failed because they don't go through the tox.ini.
