### PR TITLE
tox.ini: Add targets for pytest 2.5.2 and 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 env:
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=pypy
-    - TOXENV=py33
-    - TOXENV=py34
+    - TOXENV=py26_pytest_2.5.2
+    - TOXENV=py27_pytest_2.5.2
+    - TOXENV=pypy_pytest_2.5.2
+    - TOXENV=py33_pytest_2.5.2
+    - TOXENV=py34_pytest_2.5.2
 install:
     - travis_retry pip install tox
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist =
+    py26_pytest_2.5.2,
+    py26_pytest_2.6.1,
+    py27_pytest_2.5.2,
+    py27_pytest_2.6.1,
+    py33_pytest_2.5.2,
+    py33_pytest_2.6.1,
+    py34_pytest_2.5.2,
+    py34_pytest_2.6.1,
+    pypy_pytest_2.5.2,
+    pypy_pytest_2.6.1
 
 [testenv]
 commands = py.test {posargs}
@@ -12,9 +22,64 @@ deps =
     pytest==2.5.2
     ipdb
 
-[testenv:py26]
+[testenv:py26_pytest_2.5.2]
 commands = py.test
 deps =
     pytest==2.5.2
     ipython<2.0
+    ipdb
+
+[testenv:py26_pytest_2.6.1]
+commands = py.test
+deps =
+    pytest==2.6.1
+    ipython<2.0
+    ipdb
+
+[testenv:py27_pytest_2.5.2]
+commands = py.test
+deps =
+    pytest==2.5.2
+    ipdb
+
+[testenv:py27_pytest_2.6.1]
+commands = py.test
+deps =
+    pytest==2.6.1
+    ipdb
+
+[testenv:py33_pytest_2.5.2]
+commands = py.test
+deps =
+    pytest==2.5.2
+    ipdb
+
+[testenv:py33_pytest_2.6.1]
+commands = py.test
+deps =
+    pytest==2.6.1
+    ipdb
+
+[testenv:py34_pytest_2.5.2]
+commands = py.test
+deps =
+    pytest==2.5.2
+    ipdb
+
+[testenv:py34_pytest_2.6.1]
+commands = py.test
+deps =
+    pytest==2.6.1
+    ipdb
+
+[testenv:pypy_pytest_2.5.2]
+commands = py.test
+deps =
+    pytest==2.5.2
+    ipdb
+
+[testenv:pypy_pytest_2.6.1]
+commands = py.test
+deps =
+    pytest==2.6.1
     ipdb


### PR DESCRIPTION
because pytest-ipdb tests currently fail with pytest==2.6.1

See https://github.com/mverteuil/pytest-ipdb/issues/25 -- creating a failing test for #25 is the first step to fixing it...

```
$ tox
...
  py26_pytest_2.5.2: commands succeeded
ERROR:   py26_pytest_2.6.1: commands failed
  py27_pytest_2.5.2: commands succeeded
ERROR:   py27_pytest_2.6.1: commands failed
  py33_pytest_2.5.2: commands succeeded
ERROR:   py33_pytest_2.6.1: commands failed
  py34_pytest_2.5.2: commands succeeded
ERROR:   py34_pytest_2.6.1: commands failed
  pypy_pytest_2.5.2: commands succeeded
ERROR:   pypy_pytest_2.6.1: commands failed
```

Cc: @davidszotten 