### PR TITLE
ipdb.set_trace() vs. pytest.set_trace()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ To install
 To use: run pytest with `--ipdb` instead of `--pdb`.
 
 [![Build Status](https://travis-ci.org/mverteuil/pytest-ipdb.svg)](https://travis-ci.org/mverteuil/pytest-ipdb)
+
+Now you can breakpoints in your in your code:
+
+    import ipdb ; ipdb.set_trace()
+
+... or ...:
+
+    import pytest ; pytest.set_trace()
+
+   


### PR DESCRIPTION
This was not obvious for me if you can still use ìpdb.set_trace()` syntax...