### PR TITLE
Make version identifier PEP-440 compatible.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="pytest-ipdb",
     packages=["pytestipdb"],
-    version="0.1-prerelease2",
+    version="0.1.dev2",
     description="A py.test plug-in to enable drop to ipdb debugger on test failure.",
     author="Matthew de Verteuil",
     author_email="onceuponajooks@gmail.com",


### PR DESCRIPTION
This updates the version number to be compatible with PEP-440.
