### PR TITLE
Could we release a non-prelease build?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-pytest-ipdb
+pytest-ipdb   tttt
 ===========
 
 NOTICE


### PR DESCRIPTION
Sorry, making a PR as issues aren't enabled on this guy.

Although this project is unsupported, I still use it and it works great (pdbpp completions don't seem to work for me on Python 3 + Django).

I was hoping that you would be able to put a non-prerelease build on pypi, just to make it possible to do a simple `pip install pytest-ipdb`, as currently this will not work due to a complaint of: `Could not find a version that satisfies the requirement pytest-ipdb (from versions: 0.1-prerelease2, 0.1-prerelease2.macosx-10.9-x86_64)`

You could put up a huge statement of "THIS IS UNSUPPORTED", but it would just make it a lot easier to make use of this lib.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mverteuil/pytest-ipdb/38)

<!-- Reviewable:end -->
