### PR TITLE
docs: fix simple typo, oriainal -> original

### DIFF
--- a/pytestipdb/ptipdb.py
+++ b/pytestipdb/ptipdb.py
@@ -26,7 +26,7 @@ def patch_ipdb(config):
         ipdb.set_trace = original_trace
 
     def set_trace(frame=None):
-        # we don't want to drop in here, but at the point of the oriainal
+        # we don't want to drop in here, but at the point of the original
         # set_trace statement
         if frame is None:
             frame = sys._getframe().f_back


### PR DESCRIPTION
There is a small typo in pytestipdb/ptipdb.py.

Should read `original` rather than `oriainal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md